### PR TITLE
Add red error display for debugging

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -25,4 +25,23 @@ if (typeof window !== 'undefined') {
   });
 }
 
+// Debug-only visual error overlay (remove in production)
+if (typeof window !== 'undefined' && import.meta.env.DEV) {
+  (window as any).onerror = function(message: any, source: any, lineno: any, colno: any, error: any) {
+    const div = document.createElement("div");
+    div.style.cssText = "background:black; color:red; padding:10px; font-size:14px; white-space:pre-wrap;";
+    div.innerText = `❌ ERROR: ${message}\nSOURCE: ${source}\nLINE: ${lineno}:${colno}`;
+    document.body.innerHTML = "";
+    document.body.appendChild(div);
+  };
+
+  (window as any).onunhandledrejection = function(event: any) {
+    const div = document.createElement("div");
+    div.style.cssText = "background:black; color:red; padding:10px; font-size:14px; white-space:pre-wrap;";
+    div.innerText = `❌ UNHANDLED PROMISE REJECTION: ${event.reason}`;
+    document.body.innerHTML = "";
+    document.body.appendChild(div);
+  };
+}
+
 createRoot(document.getElementById("root")!).render(<App />);


### PR DESCRIPTION
Add a development-only visual error overlay to display JavaScript runtime and promise errors directly on the page for easier mobile debugging.

---
<a href="https://cursor.com/background-agent?bcId=bc-4325c2c6-ba36-4c61-802e-effea7d2a3aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4325c2c6-ba36-4c61-802e-effea7d2a3aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

