### PR TITLE
Add runtime error display and test

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -44,4 +44,21 @@ if (typeof window !== 'undefined') {
   };
 }
 
+// Dev-only manual trigger to test the error overlay via query params
+if (typeof window !== 'undefined' && import.meta.env.DEV) {
+  const searchParams = new URLSearchParams(window.location.search);
+  if (searchParams.has('throw')) {
+    setTimeout(() => {
+      const details = searchParams.get('throw') || 'manual-test';
+      throw new Error(`Test runtime error: ${details}`);
+    }, 0);
+  }
+  if (searchParams.has('reject')) {
+    setTimeout(() => {
+      const details = searchParams.get('reject') || 'manual-test';
+      Promise.reject(`Test unhandled rejection: ${details}`);
+    }, 0);
+  }
+}
+
 createRoot(document.getElementById("root")!).render(<App />);


### PR DESCRIPTION
Add dev-only URL query parameter triggers to `src/main.tsx` to easily test global error overlay visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-24923f71-6977-473e-a008-474c098312c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-24923f71-6977-473e-a008-474c098312c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

